### PR TITLE
Fix build & adjust version bounds

### DIFF
--- a/Database/CDB/Write.hs
+++ b/Database/CDB/Write.hs
@@ -10,6 +10,7 @@ import Control.Monad
 import Control.Monad.State
 import Data.Array.IO
 import Data.Array.Unboxed
+import Data.Array.Unsafe (unsafeFreeze)
 import qualified Data.ByteString as ByteString
 import Data.ByteString (ByteString)
 import Data.IORef

--- a/hs-cdb.cabal
+++ b/hs-cdb.cabal
@@ -22,8 +22,13 @@ cabal-version: >= 1.6
 build-type:Simple
 
 Library
-  Build-Depends:array, base >= 4 && < 5, bytestring, bytestring-mmap, directory,
-                filepath, mtl
+  Build-Depends: array == 0.5.*
+               , base >= 4 && < 5
+               , bytestring
+               , bytestring-mmap == 0.2.*
+               , directory
+               , filepath
+               , mtl
   Exposed-modules:
     Database.CDB
     Database.CDB.Packable


### PR DESCRIPTION
`unsafeFreeze` moved to `Data.Array.Unsafe` in `array-0.5.0.0`.
The bound for `bytestring-mmap` (which is not a GHC bundled package)
is set to the current major version.

I suggest a minor version push & release.